### PR TITLE
Add plantuml file output

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,7 @@
             "program": "${workspaceRoot}/aa",
             "args": ["scan","-k","../Mindbody.Web.Clients/"],
             "windows": {
-                "args": ["scan", "c:\\iis\\wwwroot\\Applications\\Mindbody.Web.Clients\\",  "--kpi"]
+                "args": ["scan", "C:\\Code\\Mindbody.Web.Clients\\",  "--kpi"]
             }
         },
         {

--- a/aa
+++ b/aa
@@ -111,8 +111,8 @@ function compare(ref1,ref2){
 
 function getDateTimeForPath() {
     var now = new Date();
-    
-    return now.getFullYear() + "" + (now.getMonth() + 1) + "" + now.getDate() + "-" + now.getHours() + "" + now.getMinutes() + "" + now.getSeconds();
+    return `${now.getFullYear()}.${("0" + (now.getMonth() + 1)).slice(-2)}.${("0" + now.getDate()).slice(-2)}-${("0" + now.getHours()).slice(-2)}.${("0" + now.getMinutes()).slice(-2)}.${("0" + now.getSeconds()).slice(-2)}`;
+    // return now.getFullYear() + "" + (now.getMonth() + 1) + "" + now.getDate() + "-" + now.getHours() + "" + now.getMinutes() + "" + now.getSeconds();
 }
 
 function getOutputDir(outputArg){

--- a/lib/analyze.js
+++ b/lib/analyze.js
@@ -197,7 +197,8 @@ var analyzeModule = function(incomingOpts) {
                 writeJsonAsync("statsDict.json", totalStatsDict),
                 writeJsonAsync("tree.json", totalTree),
                 writeJsonAsync("distinctIncludes.json", statsObj.flatTree),
-                writeTextFileAsync("warnings.txt", allWarnings)
+                writeTextFileAsync("warnings.txt", allWarnings),
+                writeTextFileAsync("hierarchyDiagram.txt", treeBuilder.buildHierarchyDiagram(totalStatsDict)),
             ]);
 
             if (opts.warnings) {

--- a/lib/transform_tree.js
+++ b/lib/transform_tree.js
@@ -21,20 +21,26 @@ var treeModule = function(incomingOpts) {
     }
 
     // Assembles a tree hierarchy into a plantuml diagram to show the visual layout
-    const SanitizeFileName = (fileName) => fileName.substring(fileName.lastIndexOf('\\') + 1).replace('-','_').replace('.asp','');
+    const SanitizeFileName = (fileName) => fileName
+        .substring(fileName.lastIndexOf('\\') + 1)  // Remove any directory symbols for object titles, and use this only in the path
+        .replace('-','_')                           // Remove any dashes which will cause plantuml to error because that isn't supported in object titles
+        .replace('.asp','');                        // Remove any ".asp" file endings for object titles to avoid treating them as namespaces
+
     function buildHierarchyDiagram(stats) {
         let hierarchyDiagram = '@startuml\n\nleft to right direction\n\n';
         for (var file in stats) {
             if (stats.hasOwnProperty(file)) {
                 const path = file;
-                const name = SanitizeFileName(file);
-                const { loc: linesOfCode, inc: includes } = stats[file];
-                const includesStr = includes.reduce((agg, include, i, a) => {
-                    return agg + `${name} <-- ${SanitizeFileName(include)}` + ((i < a.length - 1) ?  '\n' : '');
+                const sanitizedFilename = SanitizeFileName(file);
+                const { loc: linesOfCode, inc: includedFiles } = stats[file];
+                const includesStr = includedFiles.reduce((agg, includedFilename, i, a) => {
+                    const sanitizedIncludedFilename = SanitizeFileName(includedFilename);
+                    const optionalLineBreak = ((i < a.length - 1) ?  '\n' : '');
+                    return agg + `${sanitizedFilename} <-- ${sanitizedIncludedFilename}${optionalLineBreak}`;
                 }, '');
                 hierarchyDiagram += `
 ${includesStr}
-object ${name} {
+object ${sanitizedFilename} {
     path: ${path}
     lines: ${linesOfCode}
 }`;

--- a/lib/transform_tree.js
+++ b/lib/transform_tree.js
@@ -21,15 +21,16 @@ var treeModule = function(incomingOpts) {
     }
 
     // Assembles a tree hierarchy into a plantuml diagram to show the visual layout
+    const SanitizeFileName = (fileName) => fileName.substring(fileName.lastIndexOf('\\') + 1).replace('-','_').replace('.asp','');
     function buildHierarchyDiagram(stats) {
-        let hierarchyDiagram = '@startuml\n';
+        let hierarchyDiagram = '@startuml\n\nleft to right direction\n\n';
         for (var file in stats) {
             if (stats.hasOwnProperty(file)) {
                 const path = file;
-                const name = file.substring(file.lastIndexOf('\\') + 1).replace('-','_');
+                const name = SanitizeFileName(file);
                 const { loc: linesOfCode, inc: includes } = stats[file];
                 const includesStr = includes.reduce((agg, include, i, a) => {
-                    return agg + `${name} <-- ${include.substring(include.lastIndexOf('\\') + 1).replace('-','_')}` + ((i < a.length - 1) ?  '\n' : '');
+                    return agg + `${name} <-- ${SanitizeFileName(include)}` + ((i < a.length - 1) ?  '\n' : '');
                 }, '');
                 hierarchyDiagram += `
 ${includesStr}

--- a/lib/transform_tree.js
+++ b/lib/transform_tree.js
@@ -26,10 +26,10 @@ var treeModule = function(incomingOpts) {
         for (var file in stats) {
             if (stats.hasOwnProperty(file)) {
                 const path = file;
-                const name = file.substring(file.lastIndexOf('/') + 1);
+                const name = file.substring(file.lastIndexOf('\\') + 1).replace('-','_');
                 const { loc: linesOfCode, inc: includes } = stats[file];
                 const includesStr = includes.reduce((agg, include, i, a) => {
-                    return agg + `${name} <-- ${include.substring(include.lastIndexOf('/') + 1)}` + ((i < a.length - 1) ?  '\n' : '');
+                    return agg + `${name} <-- ${include.substring(include.lastIndexOf('\\') + 1).replace('-','_')}` + ((i < a.length - 1) ?  '\n' : '');
                 }, '');
                 hierarchyDiagram += `
 ${includesStr}

--- a/lib/transform_tree.js
+++ b/lib/transform_tree.js
@@ -20,6 +20,30 @@ var treeModule = function(incomingOpts) {
         return treeCache;
     }
 
+    // Assembles a tree hierarchy into a plantuml diagram to show the visual layout
+    function buildHierarchyDiagram(stats) {
+        let hierarchyDiagram = '@startuml\n';
+        for (var file in stats) {
+            if (stats.hasOwnProperty(file)) {
+                const path = file;
+                const name = file.substring(file.lastIndexOf('/') + 1);
+                const { loc: linesOfCode, inc: includes } = stats[file];
+                const includesStr = includes.reduce((agg, include, i, a) => {
+                    return agg + `${name} <-- ${include.substring(include.lastIndexOf('/') + 1)}` + ((i < a.length - 1) ?  '\n' : '');
+                }, '');
+                hierarchyDiagram += `
+${includesStr}
+object ${name} {
+    path: ${path}
+    lines: ${linesOfCode}
+}`;
+            }
+            hierarchyDiagram += '\n';
+        }
+        hierarchyDiagram += '\n@enduml';
+        return hierarchyDiagram;
+    }
+
     function buildIndividualTree(file, incArray)
     {
         if (treeCache.hasOwnProperty(file)) {
@@ -84,7 +108,8 @@ var treeModule = function(incomingOpts) {
     return {
         //buildTree: buildTree,
         buildDictTree: buildDictTree,
-        flattenTree : flattenTree
+        flattenTree : flattenTree,
+        buildHierarchyDiagram: buildHierarchyDiagram,
     };
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "simple-git": "1.71.0"
     },
     "scripts": {
-        "test": "node ./tests/*.js"
+        "test": "node ./tests/transform_tree.js"
     },
     "author": "bnowel",
     "contributors": [

--- a/tests/transform_tree.js
+++ b/tests/transform_tree.js
@@ -29,9 +29,38 @@ const expectedDictTree =
         }
     };
 
+    const expectedHierarchyDiagram = 
+`@startuml
+
+a1.asp <-- inc1.asp
+a1.asp <-- inc2.asp
+a1.asp <-- inc3.asp
+object a1.asp {
+    path: adm/a1.asp
+    lines: 12
+}
+
+inc1.asp <-- inc3.asp
+object inc1.asp {
+    path: inc1.asp
+    lines: 12
+}
 
 
-const treeModule = require("../transform_tree.js")({});
+object inc2.asp {
+    path: inc2.asp
+    lines: 12
+}
+
+
+object inc3.asp {
+    path: adm/inc3.asp
+    lines: 12
+}
+
+@enduml`;
+
+const treeModule = require("../lib/transform_tree.js")({});
 
 var actualTree = treeModule.buildDictTree(sampleStatsDict);
 
@@ -45,4 +74,5 @@ var expectedFlatTree = {"adm/inc3.asp":[],"inc1.asp":["adm/inc3.asp"],"inc2.asp"
 var expectedFlatTreeString = JSON.stringify(expectedFlatTree);
 var actualFlatTreeString = JSON.stringify(treeModule.flattenTree(actualTree));
 console.assert(expectedFlatTreeString == actualFlatTreeString);
+console.assert(expectedHierarchyDiagram === treeModule.buildHierarchyDiagram(sampleStatsDict));
 console.log("TREE TESTS PASSING");


### PR DESCRIPTION
- Add output txt file that can be interpreted by plantuml in order to generate a visual chart of the hierarchy
- Updated output folder to follow format YYYY.MM.DD.-HH.MM.SS instead of YYYYMMDD-HHMMSS